### PR TITLE
Deprecated API fields fixes

### DIFF
--- a/deploy/webhook-registration.yaml.tpl
+++ b/deploy/webhook-registration.yaml.tpl
@@ -22,3 +22,6 @@ webhooks:
         apiGroups: [""]
         apiVersions: ["v1"]
         resources: ["pods"]
+    admissionReviewVersions: ["v1", "v1beta1"]
+    sideEffects: None
+    failurePolicy: Ignore


### PR DESCRIPTION
* Fixed api version of the `MutatingWebhookConfiguration` resource
* Added both `sideEffects` and  `admissionReviewVersions` fields because their default value is now removed and these fields made required. (according to https://kubernetes.io/docs/reference/using-api/deprecation-guide/)
* `failurePolicy` default value has changed to `Fail` instead of `Ignore`, so I changed it back.